### PR TITLE
Updated 'linked' chatbox text behavior

### DIFF
--- a/src/main/java/com/github/dappermickie/odablock/ChatRightClickManager.java
+++ b/src/main/java/com/github/dappermickie/odablock/ChatRightClickManager.java
@@ -49,12 +49,12 @@ public class ChatRightClickManager
 				{
 					RightClickAction rightClickAction = rightClickable.get(untaggedText);
 					clientThread.invokeLater(() -> {
-						w.setAction(1, rightClickAction.getAction());
+						w.setAction(5, rightClickAction.getAction());
 						w.setOnOpListener((JavaScriptCallback) (ScriptEvent ev) -> {
 							openLink(rightClickAction);
 						});
 						w.setHasListener(true);
-						w.setNoClickThrough(true);
+						w.setNoClickThrough(false);
 						w.revalidate();
 					});
 				}


### PR DESCRIPTION
Fixes issues with not being able to scroll if you're hovering over the text with link (notifications/livestream notifications). Always have to right click open stream/link.
You can now click through the link if you have a transparent chatbox.